### PR TITLE
Use itertools.repeat over slower alternatives.

### DIFF
--- a/py_skiplist/iterators.py
+++ b/py_skiplist/iterators.py
@@ -1,13 +1,10 @@
-from itertools import dropwhile, count, cycle
+from itertools import dropwhile, count, repeat
 import random
 
 
 def geometric(p):
-    return (next(dropwhile(lambda _: random.randint(1, int(1. / p)) == 1, count())) for _ in cycle([1]))
+    return (next(dropwhile(lambda _: random.randint(1, int(1. / p)) == 1, count())) for _ in repeat(1))
 
 
-def uniform(n):
-    """
-    Simple deterministic distribution for testing internal of the skiplist
-    """
-    return (n for _ in cycle([1]))
+# Simple deterministic distribution for testing internals of the skiplist. 
+uniform = repeat


### PR DESCRIPTION
It looks like `itertools.repeat()` can be used in this code instead of the less direct things it's currently doing. `repeat(1)` is a simpler way of spelling `cycle([1])`. And this `uniform()` function can be completely replaced by `repeat()`, which provides the same behavior but with less overhead (in CPython it's implemented directly in C).